### PR TITLE
Implement el_relPfLepIso03 and passingDoubleHLTsafe for Triboson Analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.root
 *.pyc
+__init__.py

--- a/plugins/BuildFile.xml
+++ b/plugins/BuildFile.xml
@@ -7,13 +7,14 @@
   <use   name="DataFormats/PatCandidates"/>
   <use   name="DataFormats/Candidate"/>
   <use   name="CommonTools/Utils"/>
-  <use  name="CommonTools/UtilAlgos"/>
+  <use   name="CommonTools/UtilAlgos"/>
   <use   name="RecoEgamma/EgammaHLTAlgos"/>
   <use   name="TrackingTools/IPTools"/>
   <use   name="DataFormats/GeometryCommonDetAlgo"/>
   <use   name="TrackingTools/Records"/>
   <use   name="TrackingTools/TransientTrack"/>
   <use   name="DataFormats/EgammaCandidates"/>
-<use name="RecoEgamma/EgammaTools"/>
+  <use   name="RecoEgamma/EgammaTools"/>
+  <use   name="RecoEgamma/ElectronIdentification"/>
 <flags EDM_PLUGIN="1"/>
 </library>

--- a/plugins/PatEleEBEECut.cc
+++ b/plugins/PatEleEBEECut.cc
@@ -1,0 +1,28 @@
+#include "PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
+#include "RecoEgamma/ElectronIdentification/interface/EBEECutValues.h"
+
+class PatEleEBEECut : public CutApplicatorBase {
+public:
+  PatEleEBEECut(const edm::ParameterSet& c)
+      : CutApplicatorBase(c),
+      cutFormula_(c.getParameter<std::string>("cutString")),
+      cutValue_(c, "cutValue") {}
+
+  result_type operator()(const pat::ElectronPtr& cand) const final {
+    return cutFormula_(*cand) < cutValue_(cand);
+  }
+
+  double value(const reco::CandidatePtr& cand) const final {
+    pat::ElectronPtr ele(cand);
+    return cutFormula_(*ele);
+  }
+
+  CandidateType candidateType() const final { return PATELECTRON; }
+
+private:
+  StringObjectFunction<pat::Electron> cutFormula_;
+  const EBEECutValuesT<double> cutValue_;
+};
+
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, PatEleEBEECut, "PatEleEBEECut");

--- a/plugins/isolations.h
+++ b/plugins/isolations.h
@@ -1,0 +1,30 @@
+#ifndef EgammaIsolationAlgos_isolations_h
+#define EgammaIsolationAlgos_isolations_h
+
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include <Math/VectorUtil.h>
+
+template<class CandidateContainer>
+std::vector<float> computePfLeptonIsolations(CandidateContainer const& targetCandidates,
+                                             pat::PackedCandidateCollection const& pfCandidates) {
+
+  std::vector<float> leptonIsolations(targetCandidates.size());
+  for(auto const& pfcand : pfCandidates) {
+    auto absPdg = std::abs(pfcand.pdgId());
+    if(!(absPdg==11 || absPdg==13) || pfcand.fromPV() < pat::PackedCandidate::PVTight) {
+      continue;
+    }
+    for(unsigned int i = 0; i < targetCandidates.size(); ++i) {
+      auto dR = std::abs(ROOT::Math::VectorUtil::DeltaR(pfcand.p4(), targetCandidates[i].p4()));
+      // lower dR threshold to avoid adding itself
+      if (dR <= 0.3 && dR >= 0.0005){
+        leptonIsolations[i] += pfcand.p4().pt();
+      }
+    }
+  }
+
+  return leptonIsolations;
+}
+
+#endif

--- a/python/Identification/cutBasedDoubleElectronHLTPreselecition_Summer16_V1_cff.py
+++ b/python/Identification/cutBasedDoubleElectronHLTPreselecition_Summer16_V1_cff.py
@@ -1,0 +1,145 @@
+from PhysicsTools.SelectorUtils.centralIDRegistry import central_id_registry
+
+import FWCore.ParameterSet.Config as cms
+
+# Common functions and classes for ID definition are imported here:
+from RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_tools import *
+
+
+class DoubleEleHLTSelection_V1:
+    """
+    This is a container class to hold numerical cut values for either
+    the barrel or endcap set of cuts for electron cut-based HLT-safe preselection
+    """
+
+    def __init__(
+        self,
+        idName,
+        full5x5_sigmaIEtaIEtaCut,
+        dEtaInSeedCut,
+        dPhiInCut,
+        hOverECut,
+        absEInverseMinusPInverseCut,
+        # isolations
+        ecalPFClusterIsoCut,
+        hcalPFClusterIsoCut,
+        trkIsoCut,
+    ):
+        self.idName = idName
+        self.full5x5_sigmaIEtaIEtaCut = full5x5_sigmaIEtaIEtaCut
+        self.dEtaInSeedCut = dEtaInSeedCut
+        self.dPhiInCut = dPhiInCut
+        self.hOverECut = hOverECut
+        self.absEInverseMinusPInverseCut = absEInverseMinusPInverseCut
+        self.ecalPFClusterIsoCut = ecalPFClusterIsoCut
+        self.hcalPFClusterIsoCut = hcalPFClusterIsoCut
+        self.trkIsoCut = trkIsoCut
+
+
+def psetSimpleEcalPFClusterIsoCut(wpEB, wpEE):
+    return cms.PSet(
+        cutName=cms.string("PatEleEBEECut"),
+        cutString=cms.string("ecalPFClusterIso/pt"),
+        cutValueEB=cms.double(wpEB.ecalPFClusterIsoCut),
+        cutValueEE=cms.double(wpEE.ecalPFClusterIsoCut),
+        needsAdditionalProducts=cms.bool(False),
+        isIgnored=cms.bool(False),
+    )
+
+
+def psetSimpleHcalPFClusterIsoCut(wpEB, wpEE):
+    return cms.PSet(
+        cutName=cms.string("PatEleEBEECut"),
+        cutString=cms.string("hcalPFClusterIso/pt"),
+        cutValueEB=cms.double(wpEB.hcalPFClusterIsoCut),
+        cutValueEE=cms.double(wpEE.hcalPFClusterIsoCut),
+        needsAdditionalProducts=cms.bool(False),
+        isIgnored=cms.bool(False),
+    )
+
+
+def psetSimpleTrackIsoCut(wpEB, wpEE):
+    return cms.PSet(
+        cutName=cms.string("PatEleEBEECut"),
+        cutString=cms.string("dr03TkSumPt/pt"),
+        cutValueEB=cms.double(wpEB.trkIsoCut),
+        cutValueEE=cms.double(wpEE.trkIsoCut),
+        needsAdditionalProducts=cms.bool(False),
+        isIgnored=cms.bool(False),
+    )
+
+
+def configureVIDCutBasedDoubleEleHLTPreselection_V1(wpEB, wpEE):
+    parameterSet = cms.PSet(
+        idName=cms.string(wpEB.idName),  # same name stored in the _EB and _EE objects
+        cutFlow=cms.VPSet(
+            psetMinPtCut(),  # min pt cut
+            psetPhoSCEtaMultiRangeCut(),  # eta cut
+            psetPhoFull5x5SigmaIEtaIEtaCut(wpEB, wpEE),  # full 5x5 sigmaIEtaIEta cut
+            psetDEtaInSeedCut(wpEB, wpEE),  # dEtaIn seed cut
+            psetDPhiInCut(wpEB, wpEE),  # dPhiIn cut
+            psetHadronicOverEMCut(wpEB, wpEE),  # H/E cut
+            psetEInerseMinusPInverseCut(wpEB, wpEE),  # |1/e-1/p| cut
+            psetSimpleEcalPFClusterIsoCut(wpEB, wpEE),  # ECAL PF Cluster isolation
+            psetSimpleHcalPFClusterIsoCut(wpEB, wpEE),  # HCAL PF Cluster isolation
+            psetSimpleTrackIsoCut(wpEB, wpEE),  # tracker isolation cut
+        ),
+    )
+    #
+    return parameterSet
+
+
+#
+# This file implements the cuts linked in this file in the line with the text
+# "For double electron HLT triggers, one available offline emulation is...":
+# https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#HLT_safe_selection_for_2016_data
+#
+
+# Veto working point Barrel and Endcap
+idName = "cutBasedDoubleElectronHLTPreselection-Summer16-V1"
+WP_HLTSafe_EB = DoubleEleHLTSelection_V1(
+    idName,  # idName
+    0.011,  # full5x5_sigmaIEtaIEtaCut
+    0.01,  # dEtaInSeedCut
+    0.04,  # dPhiInCut
+    0.08,  # hOverECut
+    0.01,  # absEInverseMinusPInverseCut
+    # Calorimeter isolations:
+    0.45,  # ecalPFClusterIsoCut
+    0.25,  # hcalPFClusterIsoCut
+    # Tracker isolation:
+    0.2,  # trkIsoCut
+)
+
+WP_HLTSafe_EE = DoubleEleHLTSelection_V1(
+    idName,  # idName
+    0.031,  # full5x5_sigmaIEtaIEtaCut
+    0.01,  # dEtaInSeedCut - no cut
+    0.08,  # dPhiInCut - no cut
+    0.08,  # hOverECut
+    0.01,  # absEInverseMinusPInverseCut
+    # Calorimeter isolations:
+    0.45,  # ecalPFClusterIsoCut
+    0.25,  # hcalPFClusterIsoCut
+    # Tracker isolation:
+    0.2,  # trkIsoCut
+)
+
+
+#
+# Set up VID configuration for all cuts and working points
+#
+cutBasedDoubleElectronHLTPreselection_Summer16_V1 = configureVIDCutBasedDoubleEleHLTPreselection_V1(
+    WP_HLTSafe_EB, WP_HLTSafe_EE
+)
+
+
+# The MD5 sum numbers below reflect the exact set of cut variables
+# and values above. If anything changes, one has to
+# 1) comment out the lines below about the registry,
+# 2) run "calculateMD5 <this file name> <one of the VID config names just above>
+# 3) update the MD5 sum strings below and uncomment the lines again.
+#
+
+### for now until we have a database...
+cutBasedDoubleElectronHLTPreselection_Summer16_V1.isPOGApproved = cms.untracked.bool(True)

--- a/python/TnPTreeProducer_cfg.py
+++ b/python/TnPTreeProducer_cfg.py
@@ -425,6 +425,8 @@ process.tnpPhoIDs = cms.EDAnalyzer("TagProbeFitTreeProducer",
 if not options['useAOD'] :
     setattr( process.tnpEleTrig.flags, 'passingHLTsafe', cms.InputTag("probeEleHLTsafe" ) )
     setattr( process.tnpEleIDs.flags , 'passingHLTsafe', cms.InputTag("probeEleHLTsafe" ) )
+    setattr( process.tnpEleTrig.flags, 'passingDoubleHLTsafe', cms.InputTag("probeDoubleEleHLTsafe" ) )
+    setattr( process.tnpEleIDs.flags , 'passingDoubleHLTsafe', cms.InputTag("probeDoubleEleHLTsafe" ) )
 
 # Add SUSY variables to the "variables", add SUSY IDs to the "flags"
 if options['addSUSY'] :

--- a/python/egmElectronIDModules_cff.py
+++ b/python/egmElectronIDModules_cff.py
@@ -35,6 +35,7 @@ def setIDs(process, options):
     ### add only miniAOD supported IDs
     if not options['useAOD'] :
         my_id_modules.append( 'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronHLTPreselecition_Summer16_V1_cff' )
+        my_id_modules.append( 'EgammaAnalysis.TnPTreeProducer.Identification.cutBasedDoubleElectronHLTPreselecition_Summer16_V1_cff')
                  
     for idmod in my_id_modules:
         setupAllVIDIdsInModule(process, idmod, setupVIDElectronSelection)
@@ -122,6 +123,9 @@ def setIDs(process, options):
 
     process.probeEleHLTsafe = process.probeEleCutBasedVeto.clone()
     process.probeEleHLTsafe.selection = cms.InputTag("egmGsfElectronIDs:cutBasedElectronHLTPreselection-Summer16-V1")
+
+    process.probeDoubleEleHLTsafe = process.probeEleCutBasedVeto.clone()
+    process.probeDoubleEleHLTsafe.selection = cms.InputTag("egmGsfElectronIDs:cutBasedDoubleElectronHLTPreselection-Summer16-V1")
 
     process.probeEleCutBasedLoose  = process.probeEleCutBasedVeto.clone()
     process.probeEleCutBasedMedium = process.probeEleCutBasedVeto.clone()

--- a/python/egmTreesContent_cff.py
+++ b/python/egmTreesContent_cff.py
@@ -92,6 +92,10 @@ EleProbeVariablesToStore = cms.PSet(
     el_trkIso        = cms.string("trackIso"),
     el_dr03TkSumPt   = cms.string("dr03TkSumPt"),
 
+    # this relative PF lepton isolation component is added to the standard PF isolation sum
+    # in order to get the isolation variable used in the triboson analysis
+    el_relPfLepIso03 = cms.InputTag("eleVarHelper:pfLeptonIsolation"),
+
     #added for VHbbEIso
     el_sumPUPt       = cms.string("pfIsolationVariables().sumPUPt"),
     el_reliso03      = cms.string("(pfIsolationVariables().sumChargedHadronPt + max(pfIsolationVariables().sumNeutralHadronEt + pfIsolationVariables().sumPhotonEt - 0.5 * pfIsolationVariables().sumPUPt,0.0)) / pt() "),

--- a/python/egmTreesSetup_cff.py
+++ b/python/egmTreesSetup_cff.py
@@ -258,6 +258,7 @@ def setSequences(process, options):
         process.probeEle 
         )
     if not options['useAOD'] : process.ele_sequence += process.probeEleHLTsafe
+    if not options['useAOD'] : process.ele_sequence += process.probeDoubleEleHLTsafe
 
     process.pho_sequence = cms.Sequence(
         process.goodPhotons               +


### PR DESCRIPTION
Hi @tomcornelis and @lfinco!

This PR adds the two missing variables that are needed for the Triboson electron IDs to the TnPTreeProducer.

First, there is `el_relPfLepIso03`, which stores the relative PF lepton isolation as described here [1].

Second, there is `passingDoubleHLTsafe` which is probably obsolete I think but still used in some analyses like ours. These trigger safe cuts that we use are described here [1] if you follow the link on that page in the ”For double electron HLT triggers”... part. You end up on this page [3]. Then scroll down to the second to last bullet point: ”Trigger Emulation: In order to reduce the trigger inefficiency...”.

SInce this ID is not implemented in CMSSW, I added a VID implementation to this PR which is inspired by the implementation of the `passingHLTsafe` selection [4].

[1] https://indico.cern.ch/event/697081/contributions/2992992/attachments/1647819/2634235/PhilipChang20180426_WWW_ElectronSF_v3.pdf
[2] https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#HLT_safe_selection_for_2016_data
[3] https://twiki.cern.ch/twiki/bin/view/CMS/SUSLeptonSF#ID_IP_ISO_AN1
[4] https://github.com/cms-sw/cmssw/blob/CMSSW_9_4_X/RecoEgamma/ElectronIdentification/python/Identification/cutBasedElectronHLTPreselecition_Summer16_V1_cff.py