### PR TITLE
Addition of LowPtElectron ntuple production

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ ls /eos/cms/store/group/phys_egamma/tnpTuples/rasharma/2021-02-10/UL2016preVFP/m
 cmsrel CMSSW_10_2_22
 cd CMSSW_10_2_22/src
 cmsenv
-git clone -b RunIIfinal https://github.com/cms-egamma/EgammaAnalysis-TnPTreeProducer.git EgammaAnalysis/TnPTreeProducer
+git clone -b RunIIfinal git@github.com:cms-egamma/EgammaAnalysis-TnPTreeProducer.git EgammaAnalysis/TnPTreeProducer
 scram b -j8
 ```
 
@@ -59,7 +59,7 @@ scram b -j8
 cmsrel CMSSW_10_6_13
 cd CMSSW_10_6_13/src
 cmsenv
-git clone -b RunIIfinal https://github.com/cms-egamma/EgammaAnalysis-TnPTreeProducer.git EgammaAnalysis/TnPTreeProducer
+git clone -b RunIIfinal git@github.com:cms-egamma/EgammaAnalysis-TnPTreeProducer.git EgammaAnalysis/TnPTreeProducer
 scram b -j8
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ ls /eos/cms/store/group/phys_egamma/tnpTuples/rasharma/2021-02-10/UL2016preVFP/m
 cmsrel CMSSW_10_2_22
 cd CMSSW_10_2_22/src
 cmsenv
-git clone -b RunIIfinal git@github.com:cms-egamma/EgammaAnalysis-TnPTreeProducer.git EgammaAnalysis/TnPTreeProducer
+git clone -b RunIIfinal https://github.com/cms-egamma/EgammaAnalysis-TnPTreeProducer.git EgammaAnalysis/TnPTreeProducer
 scram b -j8
 ```
 
@@ -59,7 +59,7 @@ scram b -j8
 cmsrel CMSSW_10_6_13
 cd CMSSW_10_6_13/src
 cmsenv
-git clone -b RunIIfinal git@github.com:cms-egamma/EgammaAnalysis-TnPTreeProducer.git EgammaAnalysis/TnPTreeProducer
+git clone -b RunIIfinal https://github.com/cms-egamma/EgammaAnalysis-TnPTreeProducer.git EgammaAnalysis/TnPTreeProducer
 scram b -j8
 ```
 
@@ -102,3 +102,14 @@ flexibility to explore different workingpoints: you can simply put a cut on thes
 ## Description of variables
 
 Description of some of variables in the output tree is given [here](VariablesInfo.md).
+
+## LowPtElectron ntuples
+
+You can create ntuples for the LowPtElectron collection with the RunIIfinal branch and CMSSW_10_6_13 by using
+```bash
+cmsRun TnPTreeProducer_cfg.py doLowPtEleID=True
+```
+This requires samples in miniAOD v2 format. Some test files are immediately available for this by using era=UL2016miniAODv2:
+```bash
+cmsRun TnPTreeProducer_cfg.py doLowPtEleID=True era=UL2016miniAODv2
+```

--- a/python/TnPTreeProducer_cfg.py
+++ b/python/TnPTreeProducer_cfg.py
@@ -17,15 +17,17 @@ def registerOption(optionName, defaultValue, description, optionType=VarParsing.
       description
   )
 
-registerOption('isMC',        False,    'Use MC instead of data')
-registerOption('isAOD',       False,    'Use AOD samples instead of miniAOD')
-registerOption('is80X',       False,    'Compatibility to run on old 80X files')
-registerOption('doEleID',     True,     'Include tree for electron ID SF')
-registerOption('doPhoID',     True,     'Include tree for photon ID SF')
-registerOption('doTrigger',   True,     'Include tree for trigger SF')
-registerOption('doRECO',      False,    'Include tree for Reco SF (requires AOD)')
-registerOption('calibEn',     False,    'Use EGM smearer to calibrate photon and electron energy')
-registerOption('includeSUSY', False,    'Add also the variables used by SUSY')
+
+registerOption('isMC',         False,    'Use MC instead of data')
+registerOption('isAOD',        False,    'Use AOD samples instead of miniAOD')
+registerOption('is80X',        False,    'Compatibility to run on old 80X files')
+registerOption('doEleID',      True,     'Include tree for electron ID SF')
+registerOption('doLowPtEleID', False,    'Include tree for LowPtElectron ID SF')
+registerOption('doPhoID',      True,     'Include tree for photon ID SF')
+registerOption('doTrigger',    True,     'Include tree for trigger SF')
+registerOption('doRECO',       False,    'Include tree for Reco SF (requires AOD)')
+registerOption('calibEn',      False,    'Use EGM smearer to calibrate photon and electron energy')
+registerOption('includeSUSY',  False,    'Add also the variables used by SUSY')
 
 registerOption('HLTname',     'HLT',    'HLT process name (default HLT)', optionType=VarParsing.varType.string) # HLTname was HLT2 in now outdated reHLT samples
 registerOption('GT',          'auto',   'Global Tag to be used', optionType=VarParsing.varType.string)
@@ -41,19 +43,21 @@ varOptions.parseArguments()
 ###################################################################
 from EgammaAnalysis.TnPTreeProducer.logger import getLogger
 log = getLogger(varOptions.logLevel)
-if varOptions.isAOD and varOptions.doEleID:    log.warning('AOD is not supported for doEleID, please consider using miniAOD')
-if varOptions.isAOD and varOptions.doPhoID:    log.warning('AOD is not supported for doPhoID, please consider using miniAOD')
-if varOptions.isAOD and varOptions.doTrigger:  log.warning('AOD is not supported for doTrigger, please consider using miniAOD')
-if not varOptions.isAOD and varOptions.doRECO: log.warning('miniAOD is not supported for doRECO, please consider using AOD')
+if varOptions.isAOD and varOptions.doEleID:      log.warning('AOD is not supported for doEleID, please consider using miniAOD')
+if varOptions.isAOD and varOptions.doLowPtEleID: log.warning('AOD is not supported for doLowPtEleID, please consider using miniAOD')
+if varOptions.isAOD and varOptions.doPhoID:      log.warning('AOD is not supported for doPhoID, please consider using miniAOD')
+if varOptions.isAOD and varOptions.doTrigger:    log.warning('AOD is not supported for doTrigger, please consider using miniAOD')
+if not varOptions.isAOD and varOptions.doRECO:   log.warning('miniAOD is not supported for doRECO, please consider using AOD')
 
 from EgammaAnalysis.TnPTreeProducer.cmssw_version import isReleaseAbove
-if varOptions.era not in ['2016', '2017', '2018', 'UL2016preVFP', 'UL2016postVFP', 'UL2017', 'UL2018']: 
+if varOptions.era not in ['2016', '2017', '2018', 'UL2016preVFP', 'UL2016postVFP', 'UL2016miniAODv2','UL2017', 'UL2018']: 
   log.error('%s is not a valid era' % varOptions.era)
 if ('UL' in varOptions.era)!=(isReleaseAbove(10, 6)):
   log.error('Inconsistent release for era %s. Use CMSSW_10_6_X for UL and CMSSW_10_2_X for rereco' % varOptions.era)
 
 if varOptions.includeSUSY: log.info('Including variables for SUSY')
 if varOptions.doEleID:     log.info('Producing electron SF tree')
+if varOptions.doLowPtEleID:     log.info('Producing LowPtElectron SF tree')
 if varOptions.doPhoID:     log.info('Producing photon SF tree')
 if varOptions.doTrigger:   log.info('Producing HLT (trigger ele) efficiency tree')
 if varOptions.doRECO:      log.info('Producing RECO SF tree')
@@ -71,10 +75,12 @@ options['HLTProcessName']       = varOptions.HLTname
 options['era']                  = varOptions.era
 
 options['ELECTRON_COLL']        = "gedGsfElectrons" if options['useAOD'] else "slimmedElectrons"
+options['LOWPTELECTRON_COLL']   = "gedGsfElectrons" if options['useAOD'] else "slimmedLowPtElectrons"
 options['PHOTON_COLL']          = "gedPhotons" if options['useAOD'] else "slimmedPhotons"
 options['SUPERCLUSTER_COLL']    = "reducedEgamma:reducedSuperClusters" ### not used in AOD
 
-options['ELECTRON_CUTS']        = "ecalEnergy*sin(superClusterPosition.theta)>5.0 &&  (abs(-log(tan(superClusterPosition.theta/2)))<2.5)"
+options['ELECTRON_CUTS']        = "ecalEnergy*sin(superClusterPosition.theta)>5.0 &&  (abs(-log(tan(superClusterPosition.theta/2)))<2.5)" 
+options['LOWPTELECTRON_CUTS']   = "ecalEnergy*sin(superClusterPosition.theta)>1.0 &&  (abs(-log(tan(superClusterPosition.theta/2)))<2.5)" #pt cut relaxed to 1 GeV
 options['SUPERCLUSTER_CUTS']    = "abs(eta)<2.5 &&  et>5.0"
 options['PHOTON_CUTS']          = "(abs(-log(tan(superCluster.position.theta/2)))<=2.5) && pt> 10"
 options['ELECTRON_TAG_CUTS']    = "(abs(-log(tan(superCluster.position.theta/2)))<=2.1) && !(1.4442<=abs(-log(tan(superClusterPosition.theta/2)))<=1.566) && pt >= 30.0"
@@ -83,6 +89,7 @@ options['MAXEVENTS']            = cms.untracked.int32(varOptions.maxEvents)
 options['DoTrigger']            = varOptions.doTrigger
 options['DoRECO']               = varOptions.doRECO
 options['DoEleID']              = varOptions.doEleID
+options['DoLowPtEleID']         = varOptions.doLowPtEleID
 options['DoPhoID']              = varOptions.doPhoID
 
 options['DEBUG']                = False 
@@ -102,6 +109,8 @@ if varOptions.GT == "auto":
     if options['era'] == '2018':   options['GLOBALTAG'] = '102X_upgrade2018_realistic_v21'
     if options['era'] == 'UL2016preVFP':  options['GLOBALTAG'] = '106X_mcRun2_asymptotic_preVFP_v9'
     if options['era'] == 'UL2016postVFP': options['GLOBALTAG'] = '106X_mcRun2_asymptotic_v15'
+    # lowpt electrons require miniAOD v2 samples
+    if options['era'] == 'UL2016miniAODv2':  options['GLOBALTAG'] = '106X_mcRun2_asymptotic_v17'
     if options['era'] == 'UL2017': options['GLOBALTAG'] = '106X_dataRun2_v28'
     if options['era'] == 'UL2018': options['GLOBALTAG'] = '106X_dataRun2_v28'
   else:
@@ -110,6 +119,7 @@ if varOptions.GT == "auto":
     if options['era'] == '2018':   options['GLOBALTAG'] = '102X_dataRun2_v13'
     if options['era'] == 'UL2016preVFP':  options['GLOBALTAG'] = '106X_dataRun2_v32'
     if options['era'] == 'UL2016postVFP': options['GLOBALTAG'] = '106X_dataRun2_v32'
+    if options['era'] == 'UL2016miniAODv2':  options['GLOBALTAG'] = '106X_dataRun2_v27'
     if options['era'] == 'UL2017': options['GLOBALTAG'] = '106X_mc2017_realistic_v7'
     if options['era'] == 'UL2018': options['GLOBALTAG'] = '106X_upgrade2018_realistic_v11_L1v1'
 else:
@@ -121,7 +131,7 @@ else:
 if '2016' in options['era']:
   options['TnPPATHS']           = cms.vstring("HLT_Ele27_eta2p1_WPTight_Gsf_v*")
   options['TnPHLTTagFilters']   = cms.vstring("hltEle27erWPTightGsfTrackIsoFilter")
-  options['TnPHLTProbeFilters'] = cms.vstring()
+  options['TnPHLTProbeFilters'] = cms.vstring() 
   options['HLTFILTERSTOMEASURE']= {"passHltEle27WPTightGsf" :                           cms.vstring("hltEle27WPTightGsfTrackIsoFilter"),
                                    "passHltEle23Ele12CaloIdLTrackIdLIsoVLLeg1L1match" : cms.vstring("hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg1Filter"),
                                    "passHltEle23Ele12CaloIdLTrackIdLIsoVLLeg2" :        cms.vstring("hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg2Filter"),
@@ -223,19 +233,24 @@ process.maxEvents = cms.untracked.PSet( input = options['MAXEVENTS'])
 ###################################################################
 process.cand_sequence = cms.Sequence( process.init_sequence + process.tag_sequence )
 if options['DoEleID'] or options['DoTrigger'] : process.cand_sequence += process.ele_sequence
+if options['DoLowPtEleID']                    : process.cand_sequence += process.lowptele_sequence
 if options['DoPhoID']                         : process.cand_sequence += process.pho_sequence
 if options['DoTrigger']                       : process.cand_sequence += process.hlt_sequence
 if options['DoRECO']                          : process.cand_sequence += process.sc_sequence
 
 process.tnpPairs_sequence = cms.Sequence()
-if options['DoTrigger'] : process.tnpPairs_sequence *= process.tnpPairingEleHLT
-if options['DoRECO']    : process.tnpPairs_sequence *= process.tnpPairingEleRec
-if options['DoEleID']   : process.tnpPairs_sequence *= process.tnpPairingEleIDs
-if options['DoPhoID']   : process.tnpPairs_sequence *= process.tnpPairingPhoIDs
+if options['DoTrigger']    : process.tnpPairs_sequence *= process.tnpPairingEleHLT
+if options['DoLowPtEleID'] : process.tnpPairs_sequence *= process.tnpPairingLowPtEleHLT
+if options['DoRECO']       : process.tnpPairs_sequence *= process.tnpPairingEleRec
+if options['DoEleID']      : process.tnpPairs_sequence *= process.tnpPairingEleIDs
+if options['DoLowPtEleID'] : process.tnpPairs_sequence *= process.tnpPairingLowPtEleIDs
+if options['DoPhoID']      : process.tnpPairs_sequence *= process.tnpPairingPhoIDs
 
 ##########################################################################
 ## TnP Trees
 ##########################################################################
+
+# Electron module
 process.tnpEleTrig = cms.EDAnalyzer("TagProbeFitTreeProducer",
                                     mcTruthCommonStuff,
                                     tnpVars.CommonStuffForGsfElectronProbe,
@@ -280,7 +295,41 @@ for probeEleModule in str(process.ele_sequence).split('+'):
   setattr(process.tnpEleIDs.flags,  probeEleModule.replace('probeEle', 'passing'), cms.InputTag(probeEleModule))
 
 
+# LowPtElectron module
+if options['DoLowPtEleID']:
+  process.tnpLowPtEleTrig = cms.EDAnalyzer("TagProbeFitTreeProducer",
+                                      mcTruthCommonStuff,
+                                      tnpVars.CommonStuffForLowPtElectronProbe,    #
+                                      tagProbePairs = cms.InputTag("tnpPairingLowPtEleHLT"),
+                                      probeMatches  = cms.InputTag("genProbeLowPtEle"),
+                                      allProbes     = cms.InputTag("probeLowPtEle"),
+                                      flags         = cms.PSet(),
+                                      )
 
+  for flag in options['HLTFILTERSTOMEASURE']:
+    setattr(process.tnpLowPtEleTrig.flags, flag, cms.InputTag(flag))
+
+
+  process.tnpLowPtEleIDs = cms.EDAnalyzer("TagProbeFitTreeProducer",
+                                      mcTruthCommonStuff,
+                                      tnpVars.CommonStuffForLowPtElectronProbe,    #
+                                      tagProbePairs = cms.InputTag("tnpPairingLowPtEleIDs"),
+                                      probeMatches  = cms.InputTag("genProbeLowPtEle"),
+                                      allProbes     = cms.InputTag("probeLowPtEle"),
+                                      flags         = cms.PSet(),
+                                      )
+
+  # ID's to store in the electron ID and trigger tree
+  # Simply look which probeEleX modules were made in egmElectronIDModules_cff.py and convert them into a passingX boolean in the tree 
+  for probeLowPtEleModule in str(process.lowptele_sequence).split('+'):
+    if not 'probeLowPtEle' in probeLowPtEleModule or probeLowPtEleModule in ['probeLowPtEle', 'probeLowPtEleL1matched']: continue
+    setattr(process.tnpLowPtEleTrig.flags, probeLowPtEleModule.replace('probeLowPtEle', 'passing'), cms.InputTag(probeLowPtEleModule))
+    setattr(process.tnpLowPtEleIDs.flags,  probeLowPtEleModule.replace('probeLowPtEle', 'passing'), cms.InputTag(probeLowPtEleModule))
+
+
+
+
+# Photon module
 process.tnpPhoIDs = cms.EDAnalyzer("TagProbeFitTreeProducer",
                                     mcTruthCommonStuff,
                                     tnpVars.CommonStuffForPhotonProbe,
@@ -310,15 +359,22 @@ if options['addSUSY'] :
 
 tnpSetup.customize( process.tnpEleTrig , options )
 tnpSetup.customize( process.tnpEleIDs  , options )
+
+if options['DoLowPtEleID']:
+  tnpSetup.customize( process.tnpLowPtEleTrig , options )
+  tnpSetup.customize( process.tnpLowPtEleIDs  , options )
+
 tnpSetup.customize( process.tnpPhoIDs  , options )
 tnpSetup.customize( process.tnpEleReco , options )
 
 
 process.tree_sequence = cms.Sequence()
-if (options['DoTrigger']): process.tree_sequence *= process.tnpEleTrig
-if (options['DoRECO'])   : process.tree_sequence *= process.tnpEleReco
-if (options['DoEleID'])  : process.tree_sequence *= process.tnpEleIDs
-if (options['DoPhoID'])  : process.tree_sequence *= process.tnpPhoIDs
+if (options['DoTrigger'])    : process.tree_sequence *= process.tnpEleTrig  
+if (options['DoLowPtEleID']) : process.tree_sequence *= process.tnpLowPtEleTrig #
+if (options['DoRECO'])       : process.tree_sequence *= process.tnpEleReco
+if (options['DoEleID'])      : process.tree_sequence *= process.tnpEleIDs
+if (options['DoLowPtEleID']) : process.tree_sequence *= process.tnpLowPtEleIDs #
+if (options['DoPhoID'])      : process.tree_sequence *= process.tnpPhoIDs
 
 ##########################################################################
 ## PATHS

--- a/python/egmElectronIDModules_cff.py
+++ b/python/egmElectronIDModules_cff.py
@@ -92,6 +92,17 @@ def setIDs(process, options):
 
     addNewProbeModule(probeSequence, 'MVA94XwpHZZisoV2', 'egmGsfElectronIDs:mvaEleID-Fall17-iso-V2-wpHZZ')
 
+    if options['DoLowPtEleID']:
+      # Add goodLowPtElectrons to probe sequence
+      #temp = cms.EDProducer('GsfElectronSelectorByValueMap' if options['useAOD'] else 'PatElectronSelectorByValueMap',
+      #                          input     = cms.InputTag("goodLowPtElectrons"),
+      #                          cut       = cms.string("pt>0"),
+      #                          selection = cms.InputTag('egmGsfElectronIDs:cutBasedElectronHLTPreselection-Summer16-V1'), #inputag
+      #                          id_cut    = cms.bool(True)
+      #                         )
+      #setattr(process, 'probeLowPtEle%s' % 'HLTsafe', temp)  #name
+      probeSequence += process.goodLowPtElectrons
+    
     #
     # For cut based 94X V2, also check partial cuts
     #

--- a/python/egmElectronMiniIsoModules_cff.py
+++ b/python/egmElectronMiniIsoModules_cff.py
@@ -12,8 +12,18 @@ def addMiniIso(process, options):
     process.probeEleMiniIso.srcForIsolationCone = cms.InputTag("packedPFCandidates")
     process.probeEleMiniIso.isolationConeDefinitions[1].ktScale = cms.double(10.)
 
+
+    process.probeLowPtEleMiniIso = egmGedGsfElectronMiniNoPileUpIsolation.clone()
+    process.probeLowPtEleMiniIso.srcToIsolate = cms.InputTag(options['LOWPTELECTRON_COLL'])
+    process.probeLowPtEleMiniIso.srcForIsolationCone = cms.InputTag("packedPFCandidates")
+    process.probeLowPtEleMiniIso.isolationConeDefinitions[1].ktScale = cms.double(10.)
+
     from RecoEgamma.EgammaIsolationAlgos.egmGedGsfElectronMiniIsolation_cfi import egmGedGsfElectronEffAreaMiniIsolation
     process.probeEleMiniIsoEffArea = egmGedGsfElectronEffAreaMiniIsolation.clone()
     process.probeEleMiniIsoEffArea.srcToIsolate = cms.InputTag(options['ELECTRON_COLL'])
     process.probeEleMiniIsoEffArea.isolationConeDefinitions[0].effAreaFile = cms.FileInPath("RecoEgamma/ElectronIdentification/data/Summer16/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_80X.txt")
+
+    process.probeLowPtEleMiniIsoEffArea = egmGedGsfElectronEffAreaMiniIsolation.clone()
+    process.probeLowPtEleMiniIsoEffArea.srcToIsolate = cms.InputTag(options['LOWPTELECTRON_COLL'])
+    process.probeLowPtEleMiniIsoEffArea.isolationConeDefinitions[0].effAreaFile = cms.FileInPath("RecoEgamma/ElectronIdentification/data/Summer16/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_80X.txt")
 

--- a/python/egmTreesContent_cff.py
+++ b/python/egmTreesContent_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+
 ##########################################################################
 ## TREE CONTENT
 #########################################################################
@@ -22,6 +23,7 @@ SCProbeVariablesToStore = cms.PSet(
     sc_e      = cms.string("energy"),
     sc_tkIso  = cms.InputTag("recoEcalCandidateHelper:scTkIso"),
     )
+
 
 EleProbeVariablesToStore = cms.PSet(
     el_eta    = cms.string("eta"),
@@ -133,6 +135,61 @@ EleProbeVariablesToStore = cms.PSet(
 
     )
 
+
+
+LowPtEleProbeVariablesToStore = cms.PSet(
+    el_eta    = cms.string("eta"),
+    el_phi    = cms.string("phi"),
+    el_abseta = cms.string("abs(eta)"),
+    el_pt     = cms.string("pt"),
+    #el_pf_pt  = cms.InputTag("eleVarHelper:pfPt"),
+    el_et     = cms.string("et"),
+    el_e      = cms.string("energy"),
+    el_q      = cms.string("charge"),
+    el_isGap  = cms.string("isGap"),
+
+    
+    ## super cluster quantities
+    el_sc_e          = cms.string("superCluster().energy"),
+    el_sc_rawE       = cms.string("superCluster().rawEnergy"),
+    el_sc_esE        = cms.string("superCluster().preshowerEnergy"),
+    el_sc_et         = cms.string("superCluster().energy*sin(superClusterPosition.theta)"),    
+    el_sc_eta        = cms.string("-log(tan(superCluster.position.theta/2))"),
+    el_sc_phi        = cms.string("superCluster.phi"),    
+    el_sc_abseta     = cms.string("abs(-log(tan(superCluster.position.theta/2)))"),
+    el_seed_e        = cms.string("superCluster.seed.energy"), 
+    el_ecalEnergy    = cms.string("ecalEnergy()"),
+
+
+    #isolation
+    el_chIso               = cms.string("pfIsolationVariables().sumChargedHadronPt"),
+    el_phoIso              = cms.string("pfIsolationVariables().sumPhotonEt"),
+    el_neuIso              = cms.string("pfIsolationVariables().sumNeutralHadronEt"),
+    el_dr03EcalRecHitSumEt = cms.string("dr03EcalRecHitSumEt"),
+    el_ecalIso             = cms.string("ecalPFClusterIso"), 
+    el_hcalIso             = cms.string("hcalPFClusterIso"), 
+    el_trkIso              = cms.string("trackIso"),
+    el_dr03TkSumPt         = cms.string("dr03TkSumPt"),
+
+    #added for VHbbEIso
+    el_sumPUPt       = cms.string("pfIsolationVariables().sumPUPt"),
+    el_relIso03_dB   = cms.string("(pfIsolationVariables().sumChargedHadronPt + max(pfIsolationVariables().sumNeutralHadronEt + pfIsolationVariables().sumPhotonEt - 0.5 * pfIsolationVariables().sumPUPt,0.0)) / pt() "),
+
+
+    # BDT ID:
+    el_ID      = cms.string("electronID('ID')"),
+    el_unbiasedID      = cms.string("electronID('unbiased')"),
+    el_ptbiasedID      = cms.string("electronID('ptbiased')"),
+
+    # mini isolation
+    # available terms: https://github.com/cms-sw/cmssw/blob/b71499200b31f749544215e3b20b82ec597eef0e/DataFormats/PatCandidates/interface/PFIsolation.h#L29
+    el_miniIsoAll = cms.string("miniPFIsolation().chargedHadronIso() + max(0.0, miniPFIsolation().photonIso() + miniPFIsolation().neutralHadronIso() - miniPFIsolation().puChargedHadronIso())"),
+    el_miniIsoChg = cms.string("miniPFIsolation().chargedHadronIso()"),
+    el_miniIsoNeu = cms.string("miniPFIsolation().neutralHadronIso()"),
+    el_miniIsoPho = cms.string("miniPFIsolation().photonIso()"),
+    el_miniIsoPu = cms.string("miniPFIsolation().puChargedHadronIso()"),
+)
+
 PhoProbeVariablesToStore = cms.PSet(
     ph_eta    = cms.string("eta"),
     ph_abseta = cms.string("abs(eta)"),
@@ -235,6 +292,10 @@ CommonStuffForGsfElectronProbe = cms.PSet(
     tagFlags       =  cms.PSet(),    
     
     )
+
+CommonStuffForLowPtElectronProbe = CommonStuffForGsfElectronProbe.clone()
+CommonStuffForLowPtElectronProbe.variables = cms.PSet(LowPtEleProbeVariablesToStore)
+
 
 CommonStuffForPhotonProbe = CommonStuffForGsfElectronProbe.clone()
 CommonStuffForPhotonProbe.variables = cms.PSet(PhoProbeVariablesToStore)

--- a/python/etc/tnpInputTestFiles_cff.py
+++ b/python/etc/tnpInputTestFiles_cff.py
@@ -20,8 +20,8 @@ filesMiniAOD_2016 = {
 
 # Some miniAOD UL testfiles, which are available now and hopefully don't get deleted too soon
 filesMiniAOD_UL2016preVFP = {
-    #'mc':   cms.untracked.vstring('file:/eos/cms/store/group/phys_egamma/tnpTuples/testFiles/RunIISummer19UL16MiniAODAPV-DYJetsToLL_M-50.root'),
-    'mc':   cms.untracked.vstring('file:/eos/user/a/akadlecs/ntuples/ntupleinput_mc.root'),
+    #'mc':   cms.untracked.vstring('file:/eos/cms/store/group/phys_egamma/tnpTuples/testFiles/RunIISummer19UL16MiniAODAPV-DYJetsToLL_M-50.root'), # this file no longer seems to work
+    'mc':   cms.untracked.vstring('file:/eos/cms/store/group/phys_egamma/tnpTuples/testFiles/RunIISummer20UL16MiniAODv2-DY1JetsToLL_M-50-106X_mcRun2_asymptotic_v17-v1.root'),
     'data': cms.untracked.vstring('file:/eos/cms/store/group/phys_egamma/tnpTuples/testFiles/SingleElectron-Run2016E-21Feb2020_UL2016_HIPM.root'),
 }
 

--- a/python/etc/tnpInputTestFiles_cff.py
+++ b/python/etc/tnpInputTestFiles_cff.py
@@ -20,7 +20,8 @@ filesMiniAOD_2016 = {
 
 # Some miniAOD UL testfiles, which are available now and hopefully don't get deleted too soon
 filesMiniAOD_UL2016preVFP = {
-    'mc':   cms.untracked.vstring('file:/eos/cms/store/group/phys_egamma/tnpTuples/testFiles/RunIISummer19UL16MiniAODAPV-DYJetsToLL_M-50.root'),
+    #'mc':   cms.untracked.vstring('file:/eos/cms/store/group/phys_egamma/tnpTuples/testFiles/RunIISummer19UL16MiniAODAPV-DYJetsToLL_M-50.root'),
+    'mc':   cms.untracked.vstring('file:/eos/user/a/akadlecs/ntuples/ntupleinput_mc.root'),
     'data': cms.untracked.vstring('file:/eos/cms/store/group/phys_egamma/tnpTuples/testFiles/SingleElectron-Run2016E-21Feb2020_UL2016_HIPM.root'),
 }
 
@@ -28,6 +29,20 @@ filesMiniAOD_UL2016postVFP = {
     'mc':   cms.untracked.vstring(''),
     'data': cms.untracked.vstring('file:/eos/cms/store/group/phys_egamma/tnpTuples/testFiles/SingleElectron-Run2016F-21Feb2020_UL2016-postVFP.root'),
 }
+
+filesMiniAOD_UL2016miniAODv2 = {
+    # test samples specifically for lowpt electron tnp production
+    # later switch to Jpsi, might be better for lowpt electrons
+    #'mc' :  cms.untracked.vstring('/store/mc/RunIISummer20UL16MiniAODv2/DY1JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_v17-v1/120000/00061BF0-5BB0-524E-A539-0CAAD8579386.root'),
+
+    'mc':   cms.untracked.vstring('file:/eos/cms/store/group/phys_egamma/tnpTuples/testFiles/RunIISummer20UL16MiniAODv2-DY1JetsToLL_M-50-106X_mcRun2_asymptotic_v17-v1.root'),
+    'data': cms.untracked.vstring('file:/eos/cms/store/group/phys_egamma/tnpTuples/testFiles/SingleElectron-UL2016_MiniAODv2-v2-Run2016H-02A3E4FE-B0AA-F546-981D-283EB73FBAC9.root'),
+
+    #'mc' :  cms.untracked.vstring('/store/mc/RunIISummer20UL16MiniAODv2/DYJetsToLL_M-50_HT-400to600_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_v17-v2/2520000/C2390145-5FF1-5E45-97B0-925095E9BAD9.root'),  
+    #'data' : cms.untracked.vstring('/store/data/Run2016H/SingleElectron/MINIAOD/UL2016_MiniAODv2-v2/120000/02A3E4FE-B0AA-F546-981D-283EB73FBAC9.root'),
+}
+
+
 
 filesMiniAOD_UL2018 = {
     'mc' :   cms.untracked.vstring('file:/eos/cms/store/group/phys_egamma/tnpTuples/testFiles/RunIISummer19UL18MiniAOD-DYJetsToEE_M-50.root'),

--- a/python/leptonMva_cff.py
+++ b/python/leptonMva_cff.py
@@ -85,7 +85,7 @@ def leptonMvaSequence(process, options, tnpVars):
 
     process.leptonMvaTOP = cms.EDProducer('LeptonMvaProducer',
       leptonMvaType        = cms.string("leptonMvaTOP"),
-      weightFile           = cms.FileInPath('EgammaAnalysis/TnPTreeProducer/data/el_TOP%s_BDTG.weights.xml' % (options['era'].replace('20', '').replace('UL', '').replace('preVFP','').replace('postVFP',''))),
+      weightFile           = cms.FileInPath('EgammaAnalysis/TnPTreeProducer/data/el_TOP%s_BDTG.weights.xml' % (options['era'].replace('20', '').replace('UL', '').replace('preVFP','').replace('postVFP','').replace('miniAODv2',''))),
       probes               = cms.InputTag('slimmedElectrons'),
       miniIsoChg           = cms.InputTag('isoForEle%s:miniIsoChg' % ('Spring15' if '2016' in options['era'] else 'Fall17')),
       miniIsoAll           = cms.InputTag('isoForEle%s:miniIsoAll' % ('Spring15' if '2016' in options['era'] else 'Fall17')),


### PR DESCRIPTION
The changes add the option to create ntuples for the LowPtElectron collection.
It can be enabled/disabled with the new doLowPtEleID command-line argument in the TnPTreeProducer_cfg. This process requires miniAOD v2 files. Some current testfiles do not support this, therefore the doLowPtEleID option is disabled by default. 
A small description has been added to the readme.

Comparison files for validation are being copied to eos.